### PR TITLE
Use os.sched_getaffinity to get number of threads when running on a scheduler

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -143,14 +143,11 @@ def _parseOut(args : argparse.Namespace) -> argparse.Namespace:
 
 def _parseJobs(args : argparse.Namespace) -> argparse.Namespace:
     if args.jobs is None or args.jobs <= 0:
-        if hasattr(os, 'sched_getaffinity'):
-            print("Using os.sched_getaffinity")
-            try:
-                args.jobs = len(os.sched_getaffinity(0))
-                return args
-            except Exception:
-                pass
-        args.jobs = max(1, psutil.cpu_count(logical=False) // 2)
+        try:
+            args.jobs = len(psutil.Process().cpu_affinity())
+        except:
+            args.jobs = max(1, psutil.cpu_count(logical=False) // 2)
+        print("Number of jobs set to {}".format(args.jobs))
     return args
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -143,6 +143,13 @@ def _parseOut(args : argparse.Namespace) -> argparse.Namespace:
 
 def _parseJobs(args : argparse.Namespace) -> argparse.Namespace:
     if args.jobs is None or args.jobs <= 0:
+        if hasattr(os, 'sched_getaffinity'):
+            print("Using os.sched_getaffinity")
+            try:
+                args.jobs = len(os.sched_getaffinity(0))
+                return args
+            except Exception:
+                pass
         args.jobs = max(1, psutil.cpu_count(logical=False) // 2)
     return args
 


### PR DESCRIPTION
`os.sched_getaffinity` gets the actual number of cores available to the current process, which on Discovery/slurm might be lower than the number of cores on the machine.